### PR TITLE
Fix for local RPM install, added tag for versionlock, added Rocky&Alm…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,11 @@ nginx_version: 1.24.0
 # Default: true
 freeze_versions: true
 
+# Used for dnf/yum-versionlock. 
+# In combination with the tag 'versionlock' youre able to just disable the versionlocks.
+version_lock_state: present
+
+
 # Used to activate the Bunkerweb ui .
 # Default: false.
 enable_ui: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,15 +7,13 @@ bunkerweb_version: 1.5.0
 # Default: 1.24.0
 nginx_version: 1.24.0
 
-# Used to not upgrade Bunkerweb and Nginx after a "apt-get upgrade".
+# Used to not upgrade Bunkerweb and Nginx after a "apt upgrade" or "dnf update".
 # There is no reason to touch it unless you know what you are doing.
 # Because Bunkerweb didn't work with the latest versions of Nginx.
 # Default: true
-freeze_versions: true
-
-# Used for dnf/yum-versionlock. 
-# In combination with the tag 'versionlock' youre able to just disable the versionlocks.
-version_lock_state: present
+freeze_versions: True
+# To disable existing versionlocks, set this to False and run the play with the tag 'versionlock' 
+versionlock: True
 
 
 # Used to activate the Bunkerweb ui .

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -20,11 +20,13 @@
     name: "python3-dnf-plugin-versionlock"
     state: "{{ version_lock_state }}"
   tags: versionlock
+  when: freeze_versions|bool == true
 - name: (Centos) Prevent nginx from being updated
   community.general.dnf_versionlock:
     state: present
     name: "{{ version_lock_state }}"
   tags: versionlock
+  when: freeze_versions|bool == true
   
 # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Centos) add bunkerweb rpm-key
@@ -70,6 +72,7 @@
   community.general.dnf_versionlock:
     state: "{{ version_lock_state }}"
     name: "bunkerweb={{ bunkerweb_version }}"
+  when: freeze_versions|bool == true
   tags: versionlock
 
 - name: (Centos) Replace /etc/bunkerweb/variables.env

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -50,7 +50,7 @@
 
 - name: Ephemeral task, Remove existing bunkerweb package
   ansible.builtin.file:
-    path: "/path/to/save/bunkerweb.rpm"
+    path: "/tmp/bunkerweb-1.5.0-1.x86_64.rpm"
     state: absent
 
 - name: Ephemeral task, remove dor final Release Download bunkerweb package

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -1,6 +1,6 @@
 ---
 - name: (Centos) Copy ../files/nginx.repo to /etc/yum.repos.d/nginx.repo
-  copy:
+  ansible.builtin.copy:
     src: ../files/nginx.repo
     dest: /etc/yum.repos.d/nginx.repo
     owner: root
@@ -8,48 +8,72 @@
     mode: 0644
     force: yes
 - name: (Centos) Install epel-release dnf
-  dnf:
+  ansible.builtin.dnf:
     name: "epel-release"
     state: present
 - name: (Centos) Install nginx dnf version {{ nginx_version }}
-  dnf:
+  ansible.builtin.dnf:
     name: "nginx-{{ nginx_version }}"
     state: present
 - name: (Centos) Install python3-dnf-plugin-versionlock
-  dnf:
+  ansible.builtin.dnf:
     name: "python3-dnf-plugin-versionlock"
-    state: present
+    state: "{{ version_lock_state }}"
+  tags: versionlock
 - name: (Centos) Prevent nginx from being updated
-  community.general.yum_versionlock:
+  community.general.dnf_versionlock:
     state: present
-    name: "nginx-{{ nginx_version }}"
+    name: "{{ version_lock_state }}"
+  tags: versionlock
+  
 # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Centos) add bunkerweb rpm-key
-#   rpm_key: 
+#   ansible.builtin.rpm_key: 
 #     key: https://packagecloud.io/bunkerity/bunkerweb/gpgkey 
 #     state: present 
 #     fingerprint: 9F5B478F976C7F30191887DCA84F8F37160CA01F
 # - name: (Centos) add bunkerweb yum repository
-#   yum_repository: 
+#   ansible.builtin.yum_repository: 
 #     name: bunkerity_bunkerweb
 #     description: Bunkerweb repo
 #     baseurl: https://packagecloud.io/bunkerity/bunkerweb/el/8/$basearch
 #     file: bunkerity_bunkerweb
 #     gpgcheck: no
+#     repo_gpgcheck: true
+#     gpgkey: https://packagecloud.io/bunkerity/bunkerweb/gpgkey
 #     state: present 
 # - name: (Centos) Install bunkerweb dnf version {{ bunkerweb_version }}
-#   dnf:
+#   ansible.builtin.dnf:
 #     name: "bunkerweb-{{ bunkerweb_version }}"
 #     state: present
   # INSTRUCTIONS FOR TESTING, REMOVE THE TASKS WHEN DONE
-- name: (Centos) Install from /data/bunkerweb.rpm
-  command: dnf install -y /data/bunkerweb.rpm
+
+- name: Ephemeral task, Remove existing bunkerweb package
+  ansible.builtin.file:
+    path: "/path/to/save/bunkerweb.rpm"
+    state: absent
+
+- name: Ephemeral task, remove dor final Release Download bunkerweb package
+  ansible.builtin.uri:
+    url: "https://packagecloud.io/bunkerity/bunkerweb/packages/el/8/bunkerweb-1.5.0-1.x86_64.rpm/download.rpm?distro_version_id=205"
+    dest: "/tmp/bunkerweb-1.5.0-1.x86_64.rpm"
+    mode: '0644'
+    return_content: no
+    validate_certs: yes
+    timeout: 30
+  when: bunkerweb_version in ["1.5.0-1", "1.5.0"]
+  
+- name: (Rhel) Install from /tmp/bunkerweb.rpm
+  command: dnf install -y /tmp/bunkerweb.rpm
+  
 - name: (Centos) Prevent bunkerweb from being updated
-  community.general.yum_versionlock:
-    state: present
+  community.general.dnf_versionlock:
+    state: "{{ version_lock_state }}"
     name: "bunkerweb={{ bunkerweb_version }}"
+  tags: versionlock
+
 - name: (Centos) Replace /etc/bunkerweb/variables.env
-  copy:
+  ansible.builtin.copy:
     src: "{{ variables_env }}"
     dest: /etc/bunkerweb/variables.env
     owner: root
@@ -58,7 +82,7 @@
     force: yes
   notify: (Handler) restart bunkerweb
 - name: (Centos) Replace /etc/bunkerweb/ui.env
-  copy:
+  ansible.builtin.copy:
     src: "{{ custom_ui }}"
     dest: /etc/bunkerweb/ui.env
     owner: root
@@ -67,13 +91,13 @@
     force: yes  
   notify: (Handler) restart bunkerweb-ui
 - name: (Centos) If var {{enable_ui}} is false, systemctl disable bunkerweb-ui
-  service:
+  ansible.builtin.service:
     name: bunkerweb-ui
     state: stopped
     enabled: no
   when: enable_ui|bool == false
 - name: (Centos) Loop dictionary {{custom_configs_path}} and copy files to /etc/bunkerweb/configs
-  copy:
+  ansible.builtin.copy:
     src: "{{ item.value }}"
     dest: /etc/bunkerweb/configs/
     owner: root
@@ -84,7 +108,7 @@
   with_dict: "{{ custom_configs_path }}"
   when: item.value != None
 - name: (Centos) Add /var/www/html with {{custom_www}}
-  copy:
+  ansible.builtin.copy:
     src: "{{ custom_www }}"
     dest: /var/www/html/
     owner: "{{ custom_www_owner }}"
@@ -94,7 +118,7 @@
   notify: (Handler) restart bunkerweb
   when: custom_www|length > 0
 - name: Recursively change permission of folders
-  file:
+  ansible.builtin.file:
     path: /var/www/html/www/{{custom_www}}
     state: directory
     recurse: yes
@@ -103,7 +127,7 @@
   notify: (Handler) restart bunkerweb
   when: custom_www|length > 0
 - name: (Centos) Add /etc/bunkerweb/plugins/ with {{custom_plugins}}
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: /etc/bunkerweb/plugins/
     owner: nginx

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -18,15 +18,13 @@
 - name: (Centos) Install python3-dnf-plugin-versionlock
   ansible.builtin.dnf:
     name: "python3-dnf-plugin-versionlock"
-    state: "{{ version_lock_state }}"
-  tags: versionlock
-  when: freeze_versions|bool == true
+    state: "{{ 'present' if versionlock else 'absent' }}"
 - name: (Centos) Prevent nginx from being updated
   community.general.dnf_versionlock:
-    state: present
-    name: "{{ version_lock_state }}"
-  tags: versionlock
+    name: "nginx-{{ nginx_version }}"
+    state: "{{ 'present' if versionlock else 'absent' }}"
   when: freeze_versions|bool == true
+  tags: versionlock
   
 # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Centos) add bunkerweb rpm-key
@@ -70,7 +68,7 @@
   
 - name: (Centos) Prevent bunkerweb from being updated
   community.general.dnf_versionlock:
-    state: "{{ version_lock_state }}"
+    state: "{{ 'present' if versionlock else 'absent' }}"
     name: "bunkerweb={{ bunkerweb_version }}"
   when: freeze_versions|bool == true
   tags: versionlock

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -36,8 +36,9 @@
 - name: (Debian) Prevent nginx from being upgraded
   dpkg_selections:
     name: nginx
-    selection: hold
+    selection: "{{ 'hold' if versionlock else 'install' }}"
   when: freeze_versions|bool == true
+  tags: versionlock
   # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Debian) add bunkerweb key
 #   apt_key:
@@ -59,8 +60,9 @@
 - name: (Debian) Prevent bunkerweb from being upgraded
   dpkg_selections:
     name: bunkerweb
-    selection: hold
+    selection: "{{ 'hold' if versionlock else 'install' }}"
   when: freeze_versions|bool == true
+  tags: versionlock
 - name: (Debian) Replace /etc/bunkerweb/variables.env
   copy:
     src: "{{ variables_env }}"

--- a/tasks/fedora.yml
+++ b/tasks/fedora.yml
@@ -12,9 +12,11 @@
     name: "python3-dnf-plugin-versionlock"
     state: present
 - name: (Fedora) Prevent nginx from being updated
-  community.general.yum_versionlock:
-    state: present
+  community.general.dnf_versionlock:
     name: "nginx-{{ nginx_version }}"
+    state: "{{ 'present' if versionlock else 'absent' }}"
+  when: freeze_versions|bool == true
+  tags: versionlock
   # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Fedora) add bunkerweb rpm-key
 #   rpm_key: 
@@ -37,9 +39,11 @@
 - name: (Fedora) Install from /data/bunkerweb.rpm
   command: dnf install -y /data/bunkerweb.rpm
 - name: (Fedora) Prevent bunkerweb from being updated
-  community.general.yum_versionlock:
-    state: present
+  community.general.dnf_versionlock:
     name: "bunkerweb={{ bunkerweb_version }}"
+    state: "{{ 'present' if versionlock else 'absent' }}"
+  when: freeze_versions|bool == true
+  tags: versionlock
 - name: (Fedora) Replace /etc/bunkerweb/variables.env
   copy:
     src: "{{ variables_env }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,12 @@
 - name: Ubuntu
   include_tasks: tasks/ubuntu.yml
   when: (ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_major_version'] == "22.04") 
+- name: RedHat
+  include_tasks: tasks/redhat.yml
+  when: (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] == "8")
 - name: CentOS
   include_tasks: tasks/centos.yml
   when: (ansible_facts['distribution'] in ['CentOS', 'AlmaLinux', 'Rocky']  and ansible_facts['distribution_major_version'] == "8") 
 - name: Fedora
   include_tasks: tasks/fedora.yml
   when: (ansible_facts['distribution'] == "Fedora" and ansible_facts['distribution_major_version'] == "37") 
-- name: RedHat
-  include_tasks: tasks/redhat.yml
-  when: (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] == "8")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   when: (ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_major_version'] == "22.04") 
 - name: CentOS
   include_tasks: tasks/centos.yml
-  when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "8") 
+  when: (ansible_facts['distribution'] in ['CentOS', 'AlmaLinux', 'Rocky']  and ansible_facts['distribution_major_version'] == "8") 
 - name: Fedora
   include_tasks: tasks/fedora.yml
   when: (ansible_facts['distribution'] == "Fedora" and ansible_facts['distribution_major_version'] == "37") 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -31,9 +31,11 @@
     name: "python3-dnf-plugin-versionlock"
     state: present
 - name: (Rhel) Prevent nginx from being updated
-  community.general.yum_versionlock:
-    state: present
+  community.general.dnf_versionlock:
     name: "nginx-{{ nginx_version }}"
+    state: "{{ 'present' if versionlock else 'absent' }}"
+  when: freeze_versions|bool == true
+  tags: versionlock
 # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Rhel) add bunkerweb rpm-key
 #   rpm_key: 
@@ -56,9 +58,11 @@
 - name: (Rhel) Install from /data/bunkerweb.rpm
   command: dnf install -y /data/bunkerweb.rpm
 - name: (Rhel) Prevent bunkerweb from being updated
-  community.general.yum_versionlock:
-    state: present
+  community.general.dnf_versionlock:
     name: "bunkerweb={{ bunkerweb_version }}"
+    state: "{{ 'present' if versionlock else 'absent' }}"
+  when: freeze_versions|bool == true
+  tags: versionlock
 - name: (Rhel) Replace /etc/bunkerweb/variables.env
   copy:
     src: "{{ variables_env }}"

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,13 +1,13 @@
 ---
 - name: (Ubuntu) Update the package list
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
 - name: (Ubuntu) Upgrade the system
-  apt:
+  ansible.builtin.apt:
     upgrade: dist
     update_cache: yes
 - name: (Ubuntu) Install packages "curl gnupg2 ca-certificates lsb-release debian-archive-keyring"
-  apt:
+  ansible.builtin.apt:
     pkg: 
     - curl
     - gnupg2
@@ -17,26 +17,27 @@
     - apt-transport-https
     state: latest
 - name: (Ubuntu) add nginx apt-key
-  apt_key: 
+  ansible.builtin.apt_key: 
     url: http://nginx.org/keys/nginx_signing.key 
     state: present 
     id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
     keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
 - name: (Ubuntu) add nginx apt repository
-  apt_repository: 
+  ansible.builtin.apt_repository: 
     repo: 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu/ jammy nginx' 
     state: present 
     filename: nginx 
     update_cache: yes
 - name: (Ubuntu) Install "nginx={{ nginx_version }}-1~jammy"
-  apt:
+  ansible.builtin.apt:
     name: "nginx={{ nginx_version }}-1~jammy"
     state: present
 - name: (Ubuntu) Prevent nginx from being upgraded
-  dpkg_selections:
+  ansible.builtin.dpkg_selections:
     name: nginx
-    selection: hold
+    selection: "{{ 'hold' if versionlock else 'install' }}"
   when: freeze_versions|bool == true
+  tags: versionlock
   # FOR FINAL RELEASE, UNCOMMENT THE FOLLOWING TASKS
 # - name: (Ubuntu) add bunkerweb apt-key
 #   apt_key: 
@@ -54,14 +55,15 @@
 #     name: "bunkerweb={{ bunkerweb_version }}"
   # INSTRUCTIONS FOR TESTING, REMOVE THE TASKS WHEN DONE
 - name: (Ubuntu) Install from /data/bunkerweb.deb
-  command: apt install -y /data/bunkerweb.deb
+  ansible.builtin.command: apt install -y /data/bunkerweb.deb
 - name: (Ubuntu) Prevent bunkerweb from being upgraded
-  dpkg_selections:
+  ansible.builtin.dpkg_selections:
     name: bunkerweb
-    selection: hold
+    selection: "{{ 'hold' if versionlock else 'install' }}"
   when: freeze_versions|bool == true
+  tags: versionlock
 - name: (Ubuntu) Replace /etc/bunkerweb/variables.env
-  copy:
+  ansible.builtin.copy:
     src: "{{ variables_env }}"
     dest: /etc/bunkerweb/variables.env
     owner: root
@@ -70,7 +72,7 @@
     force: yes  
   notify: (Handler) restart bunkerweb
 - name: (Ubuntu) Replace /etc/bunkerweb/ui.env
-  copy:
+  ansible.builtin.copy:
     src: "{{ custom_ui }}"
     dest: /etc/bunkerweb/ui.env
     owner: root
@@ -79,13 +81,13 @@
     force: yes  
   notify: (Handler) restart bunkerweb-ui
 - name: (Ubuntu) If var {{enable_ui}} is false, systemctl disable bunkerweb-ui
-  service:
+  ansible.builtin.service:
     name: bunkerweb-ui
     state: stopped
     enabled: no
   when: enable_ui|bool == false
 - name: (Ubuntu) Loop dictionary {{custom_configs_path}} and copy files to /etc/bunkerweb/configs 
-  copy:
+  ansible.builtin.copy:
     src: "{{ item.value }}"
     dest: /usr/share/bunkerweb/configs/
     owner: root
@@ -96,7 +98,7 @@
   with_dict: "{{ custom_configs_path }}"
   when: item.value != None
 - name: (Ubuntu) Add /var/www/html with {{custom_www}}
-  copy:
+  ansible.builtin.copy:
     src: "{{ custom_www }}"
     dest: /var/www/html/
     owner: "{{ custom_www_owner }}"
@@ -106,7 +108,7 @@
   notify: (Handler) restart bunkerweb
   when: custom_www|length > 0
 - name: Recursively change permission of folders
-  file:
+  ansible.builtin.file:
     path: /var/www/html/{{custom_www}}
     state: directory
     recurse: yes
@@ -115,7 +117,7 @@
   notify: (Handler) restart bunkerweb
   when: custom_www|length > 0
 - name: (Ubuntu) Add /etc/bunkerweb/plugins/ with {{custom_plugins}}
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: /etc/bunkerweb/plugins/
     owner: nginx


### PR DESCRIPTION
Incorporating changes primarily related to the CentOS task. 
It should now install.  However, I'm quite unhappy with the URI task for the packagecloud RPM download, ugly quick fix for now.
In my view, it would be beneficial for Red Hat to utilize the same CentOS task file. Maybe renaming it ro rhel-8.yml. 
Additionally, introduced a tagged job and a variable to facilitate the undoing of version locking if desired.
